### PR TITLE
feat: Offer to unlink existing tests when adding new ones. [EPM-37545]

### DIFF
--- a/libs/JiraXrayIssue.py
+++ b/libs/JiraXrayIssue.py
@@ -276,8 +276,8 @@ Then <Step 3>
 
         # Update some important fields to match the PBI
         sprint_issue = MyJiraIssue(self._jira_issue, self._jira)
-        sprint_issue.refresh_field_mapping()
         test_issue = MyJiraIssue(issue, self._jira)
+        
         product_name = sprint_issue.product.value
         test_issue.issue.update(fields={test_issue.product_fieldname: {"value": product_name},
             test_issue.team_fieldname: sprint_issue.team.id})

--- a/libs/JiraXrayIssue.py
+++ b/libs/JiraXrayIssue.py
@@ -166,6 +166,18 @@ Then <Step 3>
     def delete_tests(self):
         for test in self.get_tests():
             test.delete(deleteSubtasks=True)
+    
+    def unlink_tests(self):
+        """Unlinks all tests from the current issue"""
+        self.initialize()
+        tests = self.get_tests()
+        for test in tests:
+            links = self._jira.jira.issue(self._jira_issue.key).fields.issuelinks
+            for link in links:
+                if hasattr(link, 'outwardIssue') and link.outwardIssue.key == test.key:
+                    self._jira.jira.delete_issue_link(link.id)
+                elif hasattr(link, 'inwardIssue') and link.inwardIssue.key == test.key:
+                    self._jira.jira.delete_issue_link(link.id)
 
     def parse_test_definitions(self):
         issue = MyJiraIssue(self._jira_issue, self._jira)
@@ -264,6 +276,7 @@ Then <Step 3>
 
         # Update some important fields to match the PBI
         sprint_issue = MyJiraIssue(self._jira_issue, self._jira)
+        sprint_issue.refresh_field_mapping()
         test_issue = MyJiraIssue(issue, self._jira)
         product_name = sprint_issue.product.value
         test_issue.issue.update(fields={test_issue.product_fieldname: {"value": product_name},

--- a/libs/MyJira.py
+++ b/libs/MyJira.py
@@ -365,7 +365,7 @@ class MyJira:
         Returns:
             List of linked issues.
         """
-        linked_issues = self.jira.search_issues(f'project = {self.project_name} AND "Product[Dropdown]" in ("{self.product_name}") AND issue in linkedIssues({issue.key}) AND issuetype = "{issue_type}" ORDER BY Rank ASC')
+        linked_issues = self.jira.search_issues(f'project = {self.project_name} AND issue in linkedIssues({issue.key}) AND issuetype = "{issue_type}" ORDER BY Rank ASC')
         return linked_issues
 
     def set_story_points(self, issue: Any, points: Union[int, float]) -> None:

--- a/libs/MyJira.py
+++ b/libs/MyJira.py
@@ -365,7 +365,7 @@ class MyJira:
         Returns:
             List of linked issues.
         """
-        linked_issues = self.jira.search_issues(f'project = {self.project_name} AND issue in linkedIssues({issue.key}) AND issuetype = "{issue_type}" ORDER BY Rank ASC')
+        linked_issues = self.jira.search_issues(f'project = {self.project_name} AND "Product[Dropdown]" in ("{self.product_name}") AND issue in linkedIssues({issue.key}) AND issuetype = "{issue_type}" ORDER BY Rank ASC')
         return linked_issues
 
     def set_story_points(self, issue: Any, points: Union[int, float]) -> None:

--- a/libs/MyJiraIssue.py
+++ b/libs/MyJiraIssue.py
@@ -68,7 +68,9 @@ class MyJiraIssue:
 
                 # Unfortunately we still seem to need this
                 hard_name_mappings = {
-                    'test_results': 'customfield_10097'
+                    'test_results': 'customfield_10097',
+                    'product': 'customfield_10108',
+                    'team': 'customfield_10001'
                 }
                 
                 # Check if this field matches any of our desired mappings

--- a/libs/TkTableUi.py
+++ b/libs/TkTableUi.py
@@ -162,6 +162,10 @@ class TkTableUi:
             if self.rightclick_menu.entrycget(index, "label") == item_name:
                 self.rightclick_menu.entryconfig(index, state="normal" if enabled else "disabled")
 
+    def show_yesnocancel_dialog(self, title, message):
+        return messagebox.askyesnocancel(title, message)
+
+
     def show_yesno_dialog(self, title, message):
         return messagebox.askyesno(title, message)
 

--- a/xray-ui
+++ b/xray-ui
@@ -105,14 +105,15 @@ class XrayUi:
 
             (definitions, tests) = xray_issue.get_definitions_and_tests()
             if len(tests) > 0:
-                yes = self.ui.show_yesno_dialog("Overwrite tests", f"There are {len(tests)} xray tests already created for [{issue.key}], do you want to delete and recreate from the {len(definitions)} definitions?")
+                yes = self.ui.show_yesnocancel_dialog("Existing tests", f"There are {len(tests)} xray test(s) already created for [{issue.key}], do you want to unlink them before adding more from the {len(definitions)} definition(s)?")
+                if yes is None:
+                    return # Cancel
                 if yes:
+                    # Unlink existing tests
                     try:
-                        def delete_tests():
-                            xray_issue.delete_tests()
-                        self.ui.do_task_with_progress(delete_tests)
-                        self.create_tests(xray_issue, definitions, self.on_test_created)
-                        return
+                        def unlink_tests():
+                            xray_issue.unlink_tests()
+                        self.ui.do_task_with_progress(unlink_tests)
                     except Exception as e:
                         self.ui.show_error_dialog("Error", f"Error creating tests for {issue.key}: {e}")
             yes = self.ui.show_yesno_dialog("Create tests", f"Create {len(definitions)} new xray tests for [{issue.key}] for repository folder \"{definitions.get_folder()}\"?")


### PR DESCRIPTION
Currently when tests are already linked to an item, and new tests are being added (based on the test definitions on the ticket), the option to delete the existing tests is present.

This change removes the deletion, and instead prompts for a decision whether or not to unlink them:

Yes - Unlink the existing tests, then add new tests to the ticket, same as before.
No - Do not unlink existing tests, then move on to add the new ones.
Cancel - Do not unlink existing tests, cancel adding new tests.