### PR TITLE
Fix Description & Steps parsing

### DIFF
--- a/libs/JiraXrayIssue.py
+++ b/libs/JiraXrayIssue.py
@@ -204,6 +204,7 @@ Then <Step 3>
                             description = lines[j][lines[j].index(':') + 1:].strip()
                         elif line_lwr_j.startswith('steps:'):
                             for k in range(j + 1, len(lines)):
+                                print(f"|{lines[k]}|")
                                 line_lwr_k = lines[k].lower().strip()
                                 if line_lwr_k.startswith(('given', 'and', 'when', 'then', 'but', '|', 'example')):
                                     steps.append(lines[k].strip())
@@ -211,6 +212,7 @@ Then <Step 3>
                                     if lines[k].startswith(('  ')):
                                         steps.append(lines[k])
                                     else:
+                                        print("Alternate break")
                                         break
                             break
                         elif line_lwr_j.startswith('given'):

--- a/libs/JiraXrayIssue.py
+++ b/libs/JiraXrayIssue.py
@@ -201,7 +201,7 @@ Then <Step 3>
                         if line_lwr_j.startswith('name:') or line_lwr_j.startswith('scenario:'):
                             break
                         elif line_lwr_j.startswith('description:'):
-                            description = lines[j].split(':')[1].strip()
+                            description = lines[j][lines[j].index(':') + 1:].strip()
                         elif line_lwr_j.startswith('steps:'):
                             for k in range(j + 1, len(lines)):
                                 line_lwr_k = lines[k].lower().strip()

--- a/libs/JiraXrayIssue.py
+++ b/libs/JiraXrayIssue.py
@@ -205,7 +205,7 @@ Then <Step 3>
                         elif line_lwr_j.startswith('steps:'):
                             for k in range(j + 1, len(lines)):
                                 line_lwr_k = lines[k].lower().strip()
-                                if line_lwr_k.startswith(('given', 'and', 'when', 'then', 'but', '|', 'example')):
+                                if line_lwr_k.startswith(('given', 'and', 'when', 'then', 'but', '|', 'example', '  ')):
                                     steps.append(lines[k].strip())
                                 else:
                                     break

--- a/libs/JiraXrayIssue.py
+++ b/libs/JiraXrayIssue.py
@@ -205,9 +205,11 @@ Then <Step 3>
                         elif line_lwr_j.startswith('steps:'):
                             for k in range(j + 1, len(lines)):
                                 line_lwr_k = lines[k].lower().strip()
-                                if line_lwr_k.startswith(('given', 'and', 'when', 'then', 'but', '|', 'example', '  ')):
+                                if line_lwr_k.startswith(('given', 'and', 'when', 'then', 'but', '|', 'example')):
                                     steps.append(lines[k].strip())
                                 else:
+                                    if lines[k].lower().startswith(('  ')):
+                                        steps.append(lines[k])
                                     break
                             break
                         elif line_lwr_j.startswith('given'):

--- a/libs/JiraXrayIssue.py
+++ b/libs/JiraXrayIssue.py
@@ -204,7 +204,6 @@ Then <Step 3>
                             description = lines[j][lines[j].index(':') + 1:].strip()
                         elif line_lwr_j.startswith('steps:'):
                             for k in range(j + 1, len(lines)):
-                                print(f"|{lines[k]}|")
                                 line_lwr_k = lines[k].lower().strip()
                                 if line_lwr_k.startswith(('given', 'and', 'when', 'then', 'but', '|', 'example')):
                                     steps.append(lines[k].strip())
@@ -212,7 +211,6 @@ Then <Step 3>
                                     if lines[k].startswith(('  ')):
                                         steps.append(lines[k])
                                     else:
-                                        print("Alternate break")
                                         break
                             break
                         elif line_lwr_j.startswith('given'):

--- a/libs/JiraXrayIssue.py
+++ b/libs/JiraXrayIssue.py
@@ -208,9 +208,10 @@ Then <Step 3>
                                 if line_lwr_k.startswith(('given', 'and', 'when', 'then', 'but', '|', 'example')):
                                     steps.append(lines[k].strip())
                                 else:
-                                    if lines[k].lower().startswith(('  ')):
+                                    if lines[k].startswith(('  ')):
                                         steps.append(lines[k])
-                                    break
+                                    else:
+                                        break
                             break
                         elif line_lwr_j.startswith('given'):
                             # Automation style


### PR DESCRIPTION
Fully include description, even if it contains ':' inside the body.
Count lines prefixed with double spaces as part of the tests steps.